### PR TITLE
Make the topic configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM grafana/promtail:2.5.0
 
-RUN apt-get update && apt-get install -y dumb-init mosquitto-clients vim
+RUN echo "deb [allow-insecure=yes] http://ppa.launchpad.net/mosquitto-dev/mosquitto-ppa/ubuntu focal main" > /etc/apt/sources.list.d/mosquitto-dev-ubuntu-mosquitto-ppa-focal.list
+RUN apt-get update && apt-get install --allow-unauthenticated --no-install-recommends -y dumb-init mosquitto-clients vim
 
 RUN mkdir /mqtt-logger
 

--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,10 @@
-mosquitto_sub -h $MQTT_LOGGER_MQTT_HOSTNAME -p $MQTT_LOGGER_MQTT_PORT -u $MQTT_LOGGER_MQTT_USERNAME -P $MQTT_LOGGER_MQTT_PASSWORD -F %j -t '+/debug' -t ${MQTT_LOGGER_MQTT_TOPIC:-homeassistant/#} | promtail --stdin --config.expand-env=true --config.file=/mqtt-logger/config.yaml
+mosquitto_sub \
+    -h $MQTT_LOGGER_MQTT_HOSTNAME \
+    -p $MQTT_LOGGER_MQTT_PORT \
+    -u $MQTT_LOGGER_MQTT_USERNAME \
+    -P $MQTT_LOGGER_MQTT_PASSWORD \
+    --capath /etc/ssl/certs/ \
+    -F %j \
+    -t ${MQTT_LOGGER_MQTT_TOPIC:-homeassistant/#} \
+| promtail --stdin --config.expand-env=true --config.file=/mqtt-logger/config.yaml
 

--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,2 @@
-mosquitto_sub -h $MQTT_LOGGER_MQTT_HOSTNAME -p $MQTT_LOGGER_MQTT_PORT -u $MQTT_LOGGER_MQTT_USERNAME -P $MQTT_LOGGER_MQTT_PASSWORD -F %j -t '+/debug' -t 'homeassistant/#' | promtail --stdin --config.expand-env=true --config.file=/mqtt-logger/config.yaml
+mosquitto_sub -h $MQTT_LOGGER_MQTT_HOSTNAME -p $MQTT_LOGGER_MQTT_PORT -u $MQTT_LOGGER_MQTT_USERNAME -P $MQTT_LOGGER_MQTT_PASSWORD -F %j -t '+/debug' -t ${MQTT_LOGGER_MQTT_TOPIC:-homeassistant/#} | promtail --stdin --config.expand-env=true --config.file=/mqtt-logger/config.yaml
 


### PR DESCRIPTION
Hi,
in order to read all topics, not only *homeassistant/#*, i introduced an environment variable **$MQTT_LOGGER_MQTT_TOPIC**. 
If it is not set, then *homeassistant/#* is still the default.
Gerhard